### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-##[PlayStoreLinks_Bot](http://www.reddit.com/u/PlayStoreLinks__Bot)
+## [PlayStoreLinks_Bot](http://www.reddit.com/u/PlayStoreLinks__Bot)
 
 A Reddit bot that links to Android Apps from the Play Store when a user asks to do it.
 
 
-####What's included
+#### What's included
 
 * LinkMeBot.py, the main program
 * App.py, a class that the bot uses to save data
@@ -14,7 +14,7 @@ A Reddit bot that links to Android Apps from the Play Store when a user asks to 
 * README, this file
 
 
-####What you need to know before editing this bot / running it on your local machine
+#### What you need to know before editing this bot / running it on your local machine
 
 The bot was written on an Arch machine with Python 3
 
@@ -23,26 +23,26 @@ See required packages in requirements.txt
 You need to set a valid username and password in the config file
 Also in the config file you need to set the subreddits where the bot searches for comments
 
-####How to use it
+#### How to use it
 
 On the server I use the bot is set to run every two minutes using a cronjob
 If you want to test the code I suggest you to post a comment in a subreddit and then run the bot, after configuring it.
 
 
-####Info / Reddit-related questions / See the bot in action
+#### Info / Reddit-related questions / See the bot in action
 
 http://www.reddit.com/r/cris9696
 
 Feel free to make a new post if you want to test the bot, or just use an existing one.
 
 
-####TODO
+#### TODO
 
 * Autodelete
 * Database
 
 
-####Want to help or want help?
+#### Want to help or want help?
 
 * If you want to help please feel free to do it.
 
@@ -51,7 +51,7 @@ Feel free to make a new post if you want to test the bot, or just use an existin
 * If you find any bug or exploit please tell me: I will try to fix them or if you want you can fix them and I will include your changes in the project.
 * If you find a way to improve the bot, please share it with everybody.
 
-####LICENSE
+#### LICENSE
 
 MIT License
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
